### PR TITLE
cabal: set upper bound on base version to <5

### DIFF
--- a/pusher-ws.cabal
+++ b/pusher-ws.cabal
@@ -62,7 +62,7 @@ library
                      , Network.Pusher.WebSockets.Internal.Event
                      , Paths_pusher_ws
   -- other-extensions:    
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && <5
                      , aeson
                      , bytestring
                      , containers


### PR DESCRIPTION
This sets upper bound constrain on version of base package to less than 5 so it could be built on newer ecosystem or with libraries depending on new stuff.

Enjoy! :)